### PR TITLE
Updated the daily consumption URL

### DIFF
--- a/pyrympro/const.py
+++ b/pyrympro/const.py
@@ -11,5 +11,5 @@ class Endpoint(Enum):
   ACCOUNT_INFO = f"{CONSUMER_URL}/me"
   LAST_READ = f"{CONSUMPTION_URL}/last-read"
   CONSUMPTION_FORECAST = f"{CONSUMPTION_URL}/forecast/{{meter_id}}"
-  DAILY_CONSUMPTION = f"{CONSUMPTION_URL}/daily/lastbillingCycle/{{meter_id}}/{{start_date}}/{{end_date}}"
+  DAILY_CONSUMPTION = f"{CONSUMPTION_URL}/daily/{{meter_id}}/{{start_date}}/{{end_date}}"
   MONTHLY_CONSUMPTION = f"{CONSUMPTION_URL}/monthly/{{meter_id}}/{{start_date}}/{{end_date}}"


### PR DESCRIPTION
The daily consumption query URL now adheres to the same format as the monthly consumption's.

The `lastbillingCycle` one now returns 404.